### PR TITLE
Fix repository URL in `package.json`

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "main": "build/main/index.js",
   "typings": "build/main/index.d.ts",
   "module": "build/module/index.js",
-  "repository": "https://github.com/kucherenko/jscpd-bootstrap-reporter",
+  "repository": "https://github.com/kucherenko/jscpd-badge-reporter",
   "license": "MIT",
   "keywords": [],
   "scripts": {


### PR DESCRIPTION
There is a typo that makes [npm page](https://www.npmjs.com/package/jscpd-badge-reporter) for this package points to another repository.

* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)

Doc update.

* **What is the current behavior?** (You can also link to an open issue here)

npm page points to another repository.