### PR TITLE
Support jscpd versions greater than 1.0.0-rc.6

### DIFF
--- a/package.json
+++ b/package.json
@@ -55,7 +55,7 @@
     "fs-extra": "^7.0.1"
   },
   "peerDependencies": {
-    "jscpd": "1.0.0-rc.6"
+    "jscpd": ">=1.0.0-rc.6"
   },
   "devDependencies": {
     "@types/proxyquire": "^1.3.28",


### PR DESCRIPTION
Installing this package with npm v7 and having the latest jscpd version v3 fails because of this peerDependency conflict.